### PR TITLE
fix(lint): Clean up EvidencePanel.tsx

### DIFF
--- a/src/components/evidence/EvidencePanel.tsx
+++ b/src/components/evidence/EvidencePanel.tsx
@@ -3,8 +3,8 @@
  * Componente para visualizar artículos científicos y evidencia
  */
 
-import React, { useState } from 'react';
-import { RAGQueryResult, CitationReference } from '@/core/mcp/RAGMedicalMCP';
+import React, { useState } from "react";
+import { RAGQueryResult, CitationReference } from "@/core/mcp/RAGMedicalMCP";
 
 interface EvidencePanelProps {
   ragResult?: RAGQueryResult;
@@ -20,19 +20,30 @@ interface EvidenceBadgeProps {
   confidence: number;
 }
 
-const EvidenceBadge: React.FC<EvidenceBadgeProps> = ({ level, articles, confidence }) => {
+const EvidenceBadge: React.FC<EvidenceBadgeProps> = ({
+  level,
+  articles,
+  confidence,
+}) => {
   const getBadgeColor = (level: string) => {
     switch (level) {
-      case 'Level-1': return 'bg-green-100 text-green-800 border-green-300';
-      case 'Level-2': return 'bg-blue-100 text-blue-800 border-blue-300';
-      case 'Guidelines': return 'bg-purple-100 text-purple-800 border-purple-300';
-      case 'Consensus': return 'bg-orange-100 text-orange-800 border-orange-300';
-      default: return 'bg-gray-100 text-gray-800 border-gray-300';
+      case "Level-1":
+        return "bg-green-100 text-green-800 border-green-300";
+      case "Level-2":
+        return "bg-blue-100 text-blue-800 border-blue-300";
+      case "Guidelines":
+        return "bg-purple-100 text-purple-800 border-purple-300";
+      case "Consensus":
+        return "bg-orange-100 text-orange-800 border-orange-300";
+      default:
+        return "bg-gray-100 text-gray-800 border-gray-300";
     }
   };
 
   return (
-    <span className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium border ${getBadgeColor(level)}`}>
+    <span
+      className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium border ${getBadgeColor(level)}`}
+    >
       🔬 {level} • {articles} estudios • {confidence}%
     </span>
   );
@@ -42,10 +53,22 @@ const ArticlePreview: React.FC<{
   citation: CitationReference;
   onClick?: () => void;
 }> = ({ citation, onClick }) => {
+  // Handler accesible para teclado
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!onClick) return;
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      onClick();
+    }
+  };
   return (
-    <div 
+    <div
       className="p-3 border border-gray-200 rounded-lg hover:border-blue-300 hover:shadow-sm cursor-pointer transition-all"
       onClick={onClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      aria-label={citation.title}
     >
       <div className="flex items-start justify-between">
         <div className="flex-1">
@@ -56,13 +79,15 @@ const ArticlePreview: React.FC<{
             {citation.authors} • {citation.journal} ({citation.year})
           </p>
           <div className="flex items-center gap-2">
-            <EvidenceBadge 
-              level="Level-1" 
-              articles={1} 
+            <EvidenceBadge
+              level="Level-1"
+              articles={1}
               confidence={Math.round(citation.relevance_score * 100)}
             />
             {citation.pmid && (
-              <span className="text-xs text-blue-600">PMID: {citation.pmid}</span>
+              <span className="text-xs text-blue-600">
+                PMID: {citation.pmid}
+              </span>
             )}
           </div>
         </div>
@@ -82,9 +107,11 @@ export const EvidencePanel: React.FC<EvidencePanelProps> = ({
   isLoading = false,
   onArticleClick,
   onRefresh,
-  className = ''
+  className = "",
 }) => {
-  const [expandedSection, setExpandedSection] = useState<'summary' | 'articles' | 'context'>('summary');
+  const [expandedSection, setExpandedSection] = useState<
+    "summary" | "articles" | "context"
+  >("summary");
 
   if (isLoading) {
     return (
@@ -93,7 +120,9 @@ export const EvidencePanel: React.FC<EvidencePanelProps> = ({
           <div className="flex items-center space-x-3">
             <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-blue-600"></div>
             <div>
-              <h3 className="text-sm font-medium text-blue-900">Buscando evidencia científica...</h3>
+              <h3 className="text-sm font-medium text-blue-900">
+                Buscando evidencia científica...
+              </h3>
               <p className="text-xs text-blue-700">Consultando PubMed</p>
             </div>
           </div>
@@ -108,12 +137,14 @@ export const EvidencePanel: React.FC<EvidencePanelProps> = ({
         <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
           <div className="text-center">
             <div className="text-gray-400 text-2xl mb-2">🔍</div>
-            <h3 className="text-sm font-medium text-gray-700">Sin evidencia disponible</h3>
+            <h3 className="text-sm font-medium text-gray-700">
+              Sin evidencia disponible
+            </h3>
             <p className="text-xs text-gray-500 mt-1">
               No se encontraron artículos científicos relevantes
             </p>
             {onRefresh && (
-              <button 
+              <button
                 onClick={onRefresh}
                 className="mt-2 text-xs text-blue-600 hover:text-blue-800"
               >
@@ -127,7 +158,9 @@ export const EvidencePanel: React.FC<EvidencePanelProps> = ({
   }
 
   return (
-    <div className={`evidence-panel bg-white border border-gray-200 rounded-lg ${className}`}>
+    <div
+      className={`evidence-panel bg-white border border-gray-200 rounded-lg ${className}`}
+    >
       {/* Header */}
       <div className="p-4 border-b border-gray-200">
         <div className="flex items-center justify-between">
@@ -139,7 +172,7 @@ export const EvidencePanel: React.FC<EvidencePanelProps> = ({
               {ragResult.processing_time_ms}ms
             </span>
             {onRefresh && (
-              <button 
+              <button
                 onClick={onRefresh}
                 className="text-gray-400 hover:text-gray-600 text-sm"
                 title="Actualizar evidencia"
@@ -150,24 +183,34 @@ export const EvidencePanel: React.FC<EvidencePanelProps> = ({
           </div>
         </div>
         <p className="text-sm text-gray-600 mt-1">
-          Query: "{ragResult.query}"
+          Query: &quot;{ragResult.query}&quot;
         </p>
       </div>
 
       {/* Navigation Tabs */}
       <div className="flex border-b border-gray-200">
         {[
-          { key: 'summary', label: '📊 Resumen', count: ragResult.citations.length },
-          { key: 'articles', label: '📚 Artículos', count: ragResult.citations.length },
-          { key: 'context', label: '🧠 Contexto', count: 1 }
-        ].map(tab => (
+          {
+            key: "summary",
+            label: "📊 Resumen",
+            count: ragResult.citations.length,
+          },
+          {
+            key: "articles",
+            label: "📚 Artículos",
+            count: ragResult.citations.length,
+          },
+          { key: "context", label: "🧠 Contexto", count: 1 },
+        ].map((tab) => (
           <button
             key={tab.key}
-            onClick={() => setExpandedSection(tab.key as 'summary' | 'articles' | 'context')}
+            onClick={() =>
+              setExpandedSection(tab.key as "summary" | "articles" | "context")
+            }
             className={`flex-1 px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
               expandedSection === tab.key
-                ? 'border-blue-500 text-blue-600 bg-blue-50'
-                : 'border-transparent text-gray-500 hover:text-gray-700'
+                ? "border-blue-500 text-blue-600 bg-blue-50"
+                : "border-transparent text-gray-500 hover:text-gray-700"
             }`}
           >
             {tab.label} ({tab.count})
@@ -177,16 +220,17 @@ export const EvidencePanel: React.FC<EvidencePanelProps> = ({
 
       {/* Content */}
       <div className="p-4 max-h-96 overflow-y-auto">
-        
         {/* Summary Tab */}
-        {expandedSection === 'summary' && (
+        {expandedSection === "summary" && (
           <div className="space-y-4">
             <div className="grid grid-cols-2 gap-4 text-center">
               <div className="bg-green-50 p-3 rounded-lg">
                 <div className="text-2xl font-bold text-green-600">
                   {ragResult.citations.length}
                 </div>
-                <div className="text-xs text-green-700">Artículos encontrados</div>
+                <div className="text-xs text-green-700">
+                  Artículos encontrados
+                </div>
               </div>
               <div className="bg-blue-50 p-3 rounded-lg">
                 <div className="text-2xl font-bold text-blue-600">
@@ -195,12 +239,14 @@ export const EvidencePanel: React.FC<EvidencePanelProps> = ({
                 <div className="text-xs text-blue-700">Confianza general</div>
               </div>
             </div>
-            
+
             {/* Top Article Preview */}
             {ragResult.citations.length > 0 && (
               <div>
-                <h4 className="text-sm font-medium text-gray-800 mb-2">📈 Artículo más relevante:</h4>
-                <ArticlePreview 
+                <h4 className="text-sm font-medium text-gray-800 mb-2">
+                  📈 Artículo más relevante:
+                </h4>
+                <ArticlePreview
                   citation={ragResult.citations[0]}
                   onClick={() => onArticleClick?.(ragResult.citations[0])}
                 />
@@ -210,7 +256,7 @@ export const EvidencePanel: React.FC<EvidencePanelProps> = ({
         )}
 
         {/* Articles Tab */}
-        {expandedSection === 'articles' && (
+        {expandedSection === "articles" && (
           <div className="space-y-3">
             {ragResult.citations.map((citation, index) => (
               <ArticlePreview
@@ -223,11 +269,14 @@ export const EvidencePanel: React.FC<EvidencePanelProps> = ({
         )}
 
         {/* Context Tab */}
-        {expandedSection === 'context' && (
+        {expandedSection === "context" && (
           <div>
-            <h4 className="text-sm font-medium text-gray-800 mb-2">🧠 Contexto médico generado:</h4>
+            <h4 className="text-sm font-medium text-gray-800 mb-2">
+              🧠 Contexto médico generado:
+            </h4>
             <div className="bg-gray-50 p-3 rounded-lg text-sm text-gray-700 leading-relaxed">
-              {ragResult.medical_context || 'No hay contexto médico disponible.'}
+              {ragResult.medical_context ||
+                "No hay contexto médico disponible."}
             </div>
           </div>
         )}
@@ -244,4 +293,4 @@ export const EvidencePanel: React.FC<EvidencePanelProps> = ({
   );
 };
 
-export default EvidencePanel; 
+export default EvidencePanel;


### PR DESCRIPTION
Limpieza completa de linter en src/components/evidence/EvidencePanel.tsx.
Mejora de accesibilidad:
Los elementos interactivos ahora incluyen role="button", tabIndex={0} y manejador de teclado (onKeyDown) para cumplir con los estándares de accesibilidad y el linter.
Otros cambios:
Escapado correcto de comillas dobles en el query para evitar errores de JSX (react/no-unescaped-entities).
Sin disables ni excepciones, solo código limpio y funcionalidad preservada.
El archivo ahora pasa ESLint y Prettier sin errores ni warnings.
Este PR es parte de la Operación Código Limpio para alcanzar cero errores y cero warnings en el linter.
