### PR TITLE
fix(lint): Clean up AgentExecutor.ts

### DIFF
--- a/src/core/agent/AgentExecutor.ts
+++ b/src/core/agent/AgentExecutor.ts
@@ -1,7 +1,6 @@
-import { v4 as uuidv4 } from 'uuid';
-import type { AgentContext, AgentSuggestion, MemoryBlock, SuggestionType, SuggestionField } from '@/types/agent';
-import { LLMProvider, sendToLLM, LLMResponse } from './LLMAdapter';
-import { ClinicalAgent } from './ClinicalAgent';
+import type { AgentContext, AgentSuggestion, MemoryBlock } from "@/types/agent";
+import { LLMProvider, sendToLLM, LLMResponse } from "./LLMAdapter";
+import { ClinicalAgent } from "./ClinicalAgent";
 
 /**
  * Parámetros necesarios para ejecutar el agente clínico
@@ -13,7 +12,7 @@ export interface AgentExecutionParams {
 
 /**
  * Convierte el contexto del agente en un prompt estructurado y legible para el LLM
- * 
+ *
  * @param context El contexto del agente
  * @returns String con el prompt formateado
  */
@@ -25,8 +24,8 @@ Basado en la información proporcionada, genera 2-3 sugerencias clínicas priori
 Clasifica cada sugerencia como "recommendation", "warning" o "info".
 
 CONTEXTO DEL PACIENTE:
-ID de Visita: ${context.visitId || 'No disponible'}
-ID de Paciente: ${context.metadata?.patientId || 'No disponible'}
+ID de Visita: ${context.visitId || "No disponible"}
+ID de Paciente: ${context.metadata?.patientId || "No disponible"}
 
 `;
 
@@ -34,9 +33,15 @@ ID de Paciente: ${context.metadata?.patientId || 'No disponible'}
   const blocks = Array.isArray(context.blocks) ? context.blocks : [];
 
   // Agrupar bloques por tipo
-  const contextualBlocks = blocks.filter((block: MemoryBlock) => block.type === 'contextual');
-  const persistentBlocks = blocks.filter((block: MemoryBlock) => block.type === 'persistent');
-  const semanticBlocks = blocks.filter((block: MemoryBlock) => block.type === 'semantic');
+  const contextualBlocks = blocks.filter(
+    (block: MemoryBlock) => block.type === "contextual",
+  );
+  const persistentBlocks = blocks.filter(
+    (block: MemoryBlock) => block.type === "persistent",
+  );
+  const semanticBlocks = blocks.filter(
+    (block: MemoryBlock) => block.type === "semantic",
+  );
 
   // Añadir bloques contextuales
   if (contextualBlocks.length > 0) {
@@ -44,7 +49,7 @@ ID de Paciente: ${context.metadata?.patientId || 'No disponible'}
     contextualBlocks.forEach((block: MemoryBlock) => {
       prompt += `[ID: ${block.id}] ${block.content}\n`;
     });
-    prompt += '\n';
+    prompt += "\n";
   }
 
   // Añadir bloques persistentes
@@ -53,7 +58,7 @@ ID de Paciente: ${context.metadata?.patientId || 'No disponible'}
     persistentBlocks.forEach((block: MemoryBlock) => {
       prompt += `[ID: ${block.id}] ${block.content}\n`;
     });
-    prompt += '\n';
+    prompt += "\n";
   }
 
   // Añadir bloques semánticos
@@ -62,7 +67,7 @@ ID de Paciente: ${context.metadata?.patientId || 'No disponible'}
     semanticBlocks.forEach((block: MemoryBlock) => {
       prompt += `[ID: ${block.id}] ${block.content}\n`;
     });
-    prompt += '\n';
+    prompt += "\n";
   }
 
   // Añadir instrucciones finales para el formato de respuesta
@@ -82,22 +87,31 @@ Asegúrate de incluir solo sugerencias relevantes y útiles basadas en el contex
 
 /**
  * Parsea la respuesta del LLM y la convierte en un array de objetos AgentSuggestion
- * 
+ *
  * @param llmResponse La respuesta del LLM
  * @param context El contexto original para obtener sourceBlockId válidos
  * @returns Array de objetos AgentSuggestion
  */
-function parseResponseToSuggestions(llmResponse: LLMResponse, context: AgentContext): AgentSuggestion[] {
-  console.log('parseResponseToSuggestions - Respuesta LLM recibida:', llmResponse);
-  console.log('parseResponseToSuggestions - Contexto recibido:', context);
+function parseResponseToSuggestions(
+  llmResponse: LLMResponse,
+  context: AgentContext,
+): AgentSuggestion[] {
+  console.log(
+    "parseResponseToSuggestions - Respuesta LLM recibida:",
+    llmResponse,
+  );
+  console.log("parseResponseToSuggestions - Contexto recibido:", context);
 
-  const suggestions = llmResponse.suggestions.map(suggestion => ({
+  const suggestions = llmResponse.suggestions.map((suggestion) => ({
     ...suggestion,
     createdAt: new Date(),
-    updatedAt: new Date()
+    updatedAt: new Date(),
   }));
 
-  console.log('parseResponseToSuggestions - Sugerencias procesadas:', suggestions);
+  console.log(
+    "parseResponseToSuggestions - Sugerencias procesadas:",
+    suggestions,
+  );
   return suggestions;
 }
 
@@ -106,15 +120,24 @@ export class AgentExecutor {
   private context: AgentContext;
   private provider: LLMProvider;
 
-  constructor(agent: ClinicalAgent, context: AgentContext, provider: LLMProvider) {
+  constructor(
+    agent: ClinicalAgent,
+    context: AgentContext,
+    provider: LLMProvider,
+  ) {
     this.agent = agent;
     this.context = context;
     this.provider = provider;
   }
 
-  public static async create(visitId: string, provider: LLMProvider): Promise<AgentExecutor> {
+  public static async create(
+    visitId: string,
+    provider: LLMProvider,
+  ): Promise<AgentExecutor> {
     if (!visitId) {
-      throw new Error('El ID de visita es requerido para crear el ejecutor del agente');
+      throw new Error(
+        "El ID de visita es requerido para crear el ejecutor del agente",
+      );
     }
     const agent = await ClinicalAgent.create(visitId);
     const context = await agent.getContext();
@@ -127,41 +150,44 @@ export class AgentExecutor {
 
   public async execute(): Promise<AgentSuggestion[]> {
     try {
-      console.log('AgentExecutor.execute - Contexto recibido:', {
+      console.log("AgentExecutor.execute - Contexto recibido:", {
         visitId: this.context.visitId,
         blocksCount: this.context.blocks?.length,
-        blocks: this.context.blocks
+        blocks: this.context.blocks,
       });
 
-    if (!this.context || !Array.isArray(this.context.blocks)) {
-        console.log('AgentExecutor.execute - Contexto inválido o sin bloques');
-      return [];
-    }
+      if (!this.context || !Array.isArray(this.context.blocks)) {
+        console.log("AgentExecutor.execute - Contexto inválido o sin bloques");
+        return [];
+      }
 
-    const prompt = buildPromptFromContext(this.context);
-      console.log('AgentExecutor.execute - Prompt generado:', prompt);
+      const prompt = buildPromptFromContext(this.context);
+      console.log("AgentExecutor.execute - Prompt generado:", prompt);
 
-    const llmResponse = await sendToLLM(this.context, this.provider);
-      console.log('AgentExecutor.execute - Respuesta LLM:', llmResponse);
+      const llmResponse = await sendToLLM(this.context, this.provider);
+      console.log("AgentExecutor.execute - Respuesta LLM:", llmResponse);
 
-    const suggestions = parseResponseToSuggestions(llmResponse, this.context);
-      console.log('AgentExecutor.execute - Sugerencias parseadas:', suggestions);
-    
-    // Añadir cada sugerencia al agente
-    for (const suggestion of suggestions) {
-      await this.agent.addSuggestion({
-        id: suggestion.id,
-        sourceBlockId: suggestion.sourceBlockId,
-        type: suggestion.type,
-        content: suggestion.content,
-        field: suggestion.field
-      });
-    }
-    
-    return suggestions;
+      const suggestions = parseResponseToSuggestions(llmResponse, this.context);
+      console.log(
+        "AgentExecutor.execute - Sugerencias parseadas:",
+        suggestions,
+      );
+
+      // Añadir cada sugerencia al agente
+      for (const suggestion of suggestions) {
+        await this.agent.addSuggestion({
+          id: suggestion.id,
+          sourceBlockId: suggestion.sourceBlockId,
+          type: suggestion.type,
+          content: suggestion.content,
+          field: suggestion.field,
+        });
+      }
+
+      return suggestions;
     } catch (error) {
-      console.error('Error al ejecutar el agente:', error);
+      console.error("Error al ejecutar el agente:", error);
       return [];
     }
   }
-} 
+}


### PR DESCRIPTION
Limpieza completa de linter en src/core/agent/AgentExecutor.ts.\n- Eliminación de imports no usados (uuidv4, SuggestionType, SuggestionField).\n- Sin disables ni excepciones, solo código limpio y funcionalidad preservada.\n- El archivo ahora pasa ESLint y Prettier sin errores ni warnings.\n\nEste PR es parte de la Operación Código Limpio para alcanzar cero errores y cero warnings en el linter.