### PR TITLE
CI: ignorar cambios de documentación; build mínimo en cambios de código

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,13 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'   # <- evitar EBADENGINE
           cache: 'npm'
 
-      - name: Install deps (compat mode)
+      - name: Install deps (compat mode, sin navegadores/husky)
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+          HUSKY: '0'
         run: npm ci --legacy-peer-deps
 
       - name: Build


### PR DESCRIPTION
Node 20 + npm ci --legacy-peer-deps; saltar Playwright browsers y Husky; ignorar docs/** y *.md.