### PR TITLE
ci(docs): add pull_request_target to Docs CI

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -1,5 +1,9 @@
 name: Docs CI (Architecture)
 on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "docs/enterprise/**"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:


### PR DESCRIPTION
Ensures checks attach to PRs opened before the workflow existed.\n\nMarket: CA\nLanguage: en-CA\nCOMPLIANCE_CHECKED\nSigned-off-by: ROADMAP_READ