### PR TITLE
docs(ci): add docs quality gates (spell/link) — CA/en-CA

### DIFF
--- a/.github/custom-words.txt
+++ b/.github/custom-words.txt
@@ -1,0 +1,29 @@
+# ===== Core Product =====
+Aidux
+AiduxCare
+
+# ===== Compliance / Healthcare =====
+PHIPA
+PIPEDA
+CPO
+SOAP
+physiotherapist
+physiotherapists
+
+# ===== Stack / Platforms =====
+Firestore
+Supabase
+Langfuse
+Whisper
+Vertex
+gemini-pro
+
+# ===== Access Controls =====
+RBAC
+RLS
+CMEK
+PITR
+SEMVER
+
+# ===== Misc (keep minimal) =====
+Postgres

--- a/.github/spellcheck-config.json
+++ b/.github/spellcheck-config.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json",
+  "version": "0.2",
+  "language": "en-CA",
+  "useGitignore": true,
+  "ignorePaths": [
+    "node_modules/**",
+    ".git/**",
+    "docs/**/*.svg"
+  ],
+  "dictionaryDefinitions": [
+    {
+      "name": "custom-words",
+      "path": "./.github/custom-words.txt",
+      "description": "CTO-approved custom terms (en-CA).",
+      "addWords": true
+    }
+  ],
+  "dictionaries": ["en_CA", "custom-words"],
+  "words": [],
+  "overrides": [
+    {
+      "filename": "**/*.md",
+      "caseSensitive": false,
+      "language": "en-CA",
+      "ignoreRegExpList": [
+        "/https?:\\/\\/\\S+/",
+        "/`[^`]+`/"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -1,0 +1,54 @@
+name: Docs Quality
+
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - "docs/**/*.md"
+      - ".github/workflows/docs-quality.yml"
+      - ".github/spellcheck-config.json"
+      - ".github/custom-words.txt"
+  pull_request:
+    paths:
+      - "docs/**/*.md"
+      - ".github/workflows/docs-quality.yml"
+      - ".github/spellcheck-config.json"
+      - ".github/custom-words.txt"
+
+permissions:
+  contents: read
+
+jobs:
+  Spellcheck:
+    name: Spellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js (for cspell)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install cspell
+        run: npm install -g cspell@8
+      - name: Run cspell (en-CA) on docs/**/*.md
+        run: |
+          cspell --version
+          cspell --config .github/spellcheck-config.json "docs/**/*.md" \
+            --no-progress --show-suggestions --summary
+  Link-Check:
+    name: Link Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run lychee on docs/**/*.md
+        uses: lycheeverse/lychee-action@v1
+        with:
+          args: >-
+            --accept 200..399
+            --timeout 20
+            --max-concurrency 8
+            --no-progress
+            --verbose
+            "docs/**/*.md"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/ci-quality-check.md
+++ b/docs/ci-quality-check.md
@@ -1,0 +1,3 @@
+# Docs Quality Gates — Self-test
+This file exists to trigger **Spellcheck** (en-CA) and **Link Check**.
+Valid link: https://www.google.ca/


### PR DESCRIPTION
- Enforces spellcheck (en-CA) & linkcheck on docs/**/*.md
- Blocks merges on failures
- Custom dictionary committed

Market: CA
Language: en-CA
COMPLIANCE_CHECKED