### PR TITLE
chore(ci): enable manual dispatch for release assets/trend — en-CA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: release-assets-and-trend
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - '*'


### PR DESCRIPTION
Allows manual runs via workflow_dispatch for .github/workflows/release.yml.

Market: CA
Language: en-CA
COMPLIANCE_CHECKED
Signed-off-by: ROADMAP_READ