### PR TITLE
chore(ci): harden release assets/trend workflow — en-CA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,14 +6,29 @@ on:
       - '*'
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   eval-on-tag:
     runs-on: ubuntu-latest
     permissions:
-      contents: write    # needed by gh release / action-gh-release
+      contents: write
+    env:
+      # Tag robusto para ambos eventos (push tag / release published / manual)
+      TAG_NAME: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code (tag if available)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref_name }}
+
+      - name: Debug context
+        run: |
+          echo "event=$GITHUB_EVENT_NAME"
+          echo "ref=$GITHUB_REF"
+          echo "ref_name=$GITHUB_REF_NAME"
+          echo "tag(env.TAG_NAME)=${TAG_NAME}"
+          git rev-parse --short=8 HEAD || true
 
       - name: Use Node 20
         uses: actions/setup-node@v4
@@ -25,23 +40,28 @@ jobs:
 
       - name: Run eval and report
         run: |
+          set -euo pipefail
           mkdir -p tools/eval/reports
           npm run eval:run
           LATEST="$(ls -1t tools/eval/reports/*.jsonl | head -n1)"
-          TAG="${GITHUB_REF_NAME:-$(git describe --tags --abbrev=0)}"
           TS="$(date -u +%Y%m%dT%H%M%SZ)"
+          TAG="${TAG_NAME:-$(git describe --tags --abbrev=0 || echo unknown)}"
           JSON_OUT="tools/eval/reports/${TAG}__${TS}.jsonl"
           cp -f "$LATEST" "$JSON_OUT"
           node tools/eval/reporter-md.cjs "$JSON_OUT" > "tools/eval/reports/${TAG}__${TS}.report.md"
           npm run eval:gate
 
-      - name: Update trendline
+      - name: Update trendline (workspace)
         run: npm run eval:trend:update
 
-      - name: Commit trendline (if changed)
+      - name: Commit trendline to main (if changed)
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          set -euo pipefail
+          git fetch origin main
+          # asegura commit en main
+          git checkout -B main origin/main
+          # mueve el archivo generado desde el checkout previo si hizo falta
+          test -f tools/eval/trends/quality-trend.md || exit 0
           git add tools/eval/trends/quality-trend.md
           git diff --cached --quiet || git commit -m "chore(eval): update quality trendline
 
@@ -49,13 +69,14 @@ Market: CA
 Language: en-CA
 COMPLIANCE_CHECKED
 Signed-off-by: ROADMAP_READ"
-          git push
+          git push origin main
 
       - name: Upload assets to Release
+        if: always()
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            tools/eval/reports/${{ github.ref_name }}__*.jsonl
-            tools/eval/reports/${{ github.ref_name }}__*.report.md
+            tools/eval/reports/${{ env.TAG_NAME }}__*.jsonl
+            tools/eval/reports/${{ env.TAG_NAME }}__*.report.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add workflow_dispatch; ensure checkout uses tag on release; robust TAG_NAME; commit trendline to main; upload assets by tag.

Market: CA
Language: en-CA
COMPLIANCE_CHECKED
Signed-off-by: ROADMAP_READ