### PR TITLE
ci: wrapper → qa-eval-run

### DIFF
--- a/.github/workflows/release-assets-trend-manual.yml
+++ b/.github/workflows/release-assets-trend-manual.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   run-eval:
-    uses: Maurosg78/AIDUXCARE-V.2/.github/workflows/release-assets-trend-run.yml@main
+    uses: Maurosg78/AIDUXCARE-V.2/.github/workflows/qa-eval-run.yml@main
     with:
       tag: ${{ inputs.tag }}
     secrets: inherit

--- a/.github/workflows/zz-smoke-dispatch.yml
+++ b/.github/workflows/zz-smoke-dispatch.yml
@@ -1,0 +1,8 @@
+name: zz-smoke-dispatch
+on:
+  workflow_dispatch:
+jobs:
+  say-hi:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "hello from smoke"


### PR DESCRIPTION
El wrapper apuntaba al runner antiguo (disabled), causando runs de 0s. Ahora usa qa-eval-run.yml@main.