### PR TITLE
ci: wrapper → reusable local

### DIFF
--- a/.github/workflows/release-assets-trend-manual.yml
+++ b/.github/workflows/release-assets-trend-manual.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   run-eval:
-    uses: Maurosg78/AIDUXCARE-V.2/.github/workflows/qa-eval-run.yml@main
+    uses: ./.github/workflows/qa-eval-run.yml@main
     with:
       tag: ${{ inputs.tag }}
     secrets: inherit


### PR DESCRIPTION
Cambia uses a ruta local para workflow_call y evita filtro cross-repo.