### PR TITLE
ci: wrapper → reusable local (fix compile)

### DIFF
--- a/.github/workflows/release-assets-trend-manual.yml
+++ b/.github/workflows/release-assets-trend-manual.yml
@@ -1,4 +1,4 @@
-name: release-assets-and-trend (manual)
+name: release-assets-trend-manual
 
 on:
   workflow_dispatch:
@@ -9,8 +9,8 @@ on:
         type: string
 
 jobs:
-  run-eval:
+  run-qa-eval:
     uses: ./.github/workflows/qa-eval-run.yml
+    secrets: inherit
     with:
       tag: ${{ inputs.tag }}
-    secrets: inherit


### PR DESCRIPTION
Reescribe wrapper con plantilla mínima válida: usa ruta local, secrets: inherit e inputs → with.