### PR TITLE
fix: add tag_name to gh-release action

### DIFF
--- a/.github/workflows/qa-eval-run.yml
+++ b/.github/workflows/qa-eval-run.yml
@@ -78,6 +78,7 @@ jobs:
         if: always()
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ env.GATE_TAG }}
           files: |
             tools/eval/reports/*__*.jsonl
             tools/eval/reports/*__*.report.md


### PR DESCRIPTION
Specify GATE_TAG for release asset upload

Market: CA | Language: en-CA