### PR TITLE
docs(backlog): technical debt items

### DIFF
--- a/docs/enterprise/BACKLOG.md
+++ b/docs/enterprise/BACKLOG.md
@@ -1,0 +1,26 @@
+## Technical Debt - Low Priority
+
+### Husky Hook Cleanup
+**Issue:** Two deprecated lines in `.husky/pre-commit`  
+**Impact:** Cosmetic warning in npm output  
+**Priority:** P3 (Low)  
+**Effort:** 5 minutes  
+**Owner:** Any developer  
+
+### Dependency Updates
+**Issue:** ESLint v8.x, glob v7.x, rimraf v3.x deprecated  
+**Impact:** None currently, future compatibility risk  
+**Priority:** P3 (Low)  
+**Effort:** 2 hours (testing required)  
+**Owner:** Assign in maintenance sprint  
+
+### Onboarding Documentation
+**Issue:** Local setup instructions not in README  
+**Impact:** New developers need verbal guidance  
+**Priority:** P2 (Medium)  
+**Effort:** 30 minutes  
+**Owner:** Documentation team  
+**Action:** Add 3-step reproduction to CONTRIBUTING.md  
+
+---
+**Scheduled Review:** Next maintenance sprint (W44–W45)


### PR DESCRIPTION
Adds Husky cleanup, dependency updates, and onboarding docs to backlog.\n\nMarket: CA · Language: en-CA · Signed-off-by: ROADMAP_READ · COMPLIANCE_CHECKED