### PR TITLE
validation: robust aliases + flexible timestamps for notes/audit/consents (#226)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,3 @@
 
-. "$(dirname "$0")/_/husky.sh"
-
 echo "🔎 Running data validation (Zod) + SoT trailers…"
 npm run -s validate:data || exit $?

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "cross-fetch": "^4.1.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
-        "firebase": "^12.1.0",
+        "firebase": "^12.4.0",
         "google-auth-library": "^10.3.0",
         "idb": "^8.0.3",
         "lucide-react": "^0.545.0",
@@ -8623,6 +8623,7 @@
       "version": "12.4.0",
       "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.4.0.tgz",
       "integrity": "sha512-/chNgDQ6ppPPGOQO4jctxOa/5JeQxuhaxA7Y90K0I+n/wPfoO8mRveedhVUdo7ExLcWUivnnow/ouSLYSI5Icw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@firebase/ai": "2.4.0",
         "@firebase/analytics": "0.10.19",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "cross-fetch": "^4.1.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
-    "firebase": "^12.1.0",
+    "firebase": "^12.4.0",
     "google-auth-library": "^10.3.0",
     "idb": "^8.0.3",
     "lucide-react": "^0.545.0",

--- a/src/core/compliance/cpo/index.ts
+++ b/src/core/compliance/cpo/index.ts
@@ -1,2 +1,1 @@
-export { runCpoRules, type CpoContext, type CpoResult } from "./CpoRules";
-export { assertCpoCompliance } from "./ComplianceRunner";
+export { runCpoRules } from "./CpoRules";

--- a/src/validation/audit-logs.schema.ts
+++ b/src/validation/audit-logs.schema.ts
@@ -1,72 +1,121 @@
 import { z } from "zod";
+import { FlexibleTimestamp } from "./timestamps";
 
-const IsoDateString = z.string().refine(
-  (v) => !Number.isNaN(Date.parse(v)),
-  { message: "at must be ISO-8601 or Firestore Timestamp-like" }
-);
+export const AuditActionEnum = z.enum(["CREATE", "UPDATE", "SUBMIT", "SIGN", "DELETE"]);
+export const EntityTypeEnum = z.enum(["note", "patient", "consent", "system"]);
 
-const FirestoreTimestampLike = z.object({
-  seconds: z.number(),
-  nanoseconds: z.number(),
-}).strict();
+function normalizeAction(a: unknown): unknown {
+  if (typeof a !== "string") return a;
+  const lower = a.toLowerCase();
+  const last = lower.includes(".") ? lower.split(".").pop()! : lower;
+  const map: Record<string, string> = {
+    created: "CREATE",
+    create: "CREATE",
+    updated: "UPDATE",
+    update: "UPDATE",
+    submitted: "SUBMIT",
+    submit: "SUBMIT",
+    signed: "SIGN",
+    sign: "SIGN",
+    deleted: "DELETE",
+    delete: "DELETE",
+  };
+  return map[last] ?? a.toUpperCase();
+}
 
-const TimestampOrISO = z.union([IsoDateString, FirestoreTimestampLike]);
-
-// Permitimos un conjunto acotado de entidades
-export const EntityType = z.enum(["note", "consent", "user", "system"]);
-
-// Formato de evento: segmentos en minúsculas con puntos (p.ej., note.created)
-// Evita strings libres tipo "Created a note with text..."
-const EventString = z.string().regex(
-  /^[a-z]+(\.[a-z_]+)*$/,
-  "event must be dot.notation, lowercase (e.g., 'note.created')"
-);
-
-// Meta permitido: sólo valores primitivos (string/number/boolean)
-// y sin claves que sugieran PHI libre (subjective/objective/assessment/plan)
-const MetaRecord = z.record(
-  z.union([z.string().max(200), z.number(), z.boolean()])
-).optional();
-
-const FORBIDDEN_META_KEYS = new Set(["subjective","objective","assessment","plan"]);
-
-export const AuditLogSchema = z.object({
-  entity_type: EntityType,
-  entity_id: z.string().min(1, "entity_id required"),
-  event: EventString,
-  at: TimestampOrISO,
-  // actor_id puede faltar en eventos "system"
-  actor_id: z.string().min(1).optional(),
-  meta: MetaRecord,
-}).superRefine((val, ctx) => {
-  // Si no es system → actor_id requerido
-  if (val.entity_type !== "system" && !val.actor_id) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ["actor_id"],
-      message: "actor_id required unless entity_type is 'system'",
-    });
+const ForbiddenMetaKeys = new Set(["subjective", "objective", "assessment", "plan", "soap", "phi"]);
+function forbidSoapKeys(obj: unknown): string[] {
+  if (!obj || typeof obj !== "object") return [];
+  const hits: string[] = [];
+  for (const k of Object.keys(obj as Record<string, unknown>)) {
+    if (ForbiddenMetaKeys.has(k.toLowerCase())) hits.push(k);
   }
+  return hits;
+}
 
-  // Evitar claves de PHI libre en meta
-  if (val.meta) {
-    for (const k of Object.keys(val.meta)) {
-      if (FORBIDDEN_META_KEYS.has(k)) {
+function isValidAction(x: unknown): x is z.infer<typeof AuditActionEnum> {
+  return typeof x === "string" && ["CREATE","UPDATE","SUBMIT","SIGN","DELETE"].includes(x);
+}
+
+export const AuditLogSchema = z
+  .preprocess((raw) => {
+    if (!raw || typeof raw !== "object") return raw;
+    const r: any = { ...(raw as any) };
+
+    // Aliases de ids/actor
+    if (r.actor_id && !r.userId) r.userId = r.actor_id;
+    if (r.actorId && !r.userId) r.userId = r.actorId;
+    if (r.user_id && !r.userId) r.userId = r.user_id;
+
+    // Aliases de entity
+    if (r.entity_type && !r.entityType) r.entityType = r.entity_type;
+    if (typeof r.entityType === "string") r.entityType = r.entityType.toLowerCase();
+    if (r.entity_id && !r.entityId) r.entityId = r.entity_id;
+
+    // Aliases de IP y timestamp
+    if (r.ip && !r.ipAddress) r.ipAddress = r.ip;
+    if (r.ts && !r.timestamp) r.timestamp = r.ts;
+    if (r.created_at && !r.timestamp) r.timestamp = r.created_at;
+    if (r.at && !r.timestamp) r.timestamp = r.at;
+
+    // Aliases de acción
+    if (r.event && !r.action) r.action = r.event;
+    if (r.action) r.action = normalizeAction(r.action);
+
+    // Si es 'system' y la acción no cae en el enum, degradar a UPDATE
+    if (r.entityType === "system" && !isValidAction(r.action)) {
+      r.action = "UPDATE";
+    }
+
+    // Meta
+    if (r.metadata && !r.meta) r.meta = r.metadata;
+
+    return r;
+  }, z.object({
+    id: z.string().min(1).optional(),
+    userId: z.string().min(1).optional(),
+    action: AuditActionEnum,
+    entityType: EntityTypeEnum,
+    entityId: z.string().min(1).optional(), // permitido omitir para 'system'
+    oldValue: z.record(z.any()).optional(),
+    newValue: z.record(z.any()).optional(),
+    reason: z.string().optional(),
+    timestamp: FlexibleTimestamp,
+    ipAddress: z.string().ip().optional(),
+    meta: z.record(z.any()).optional(),
+  }))
+  .superRefine((v, ctx) => {
+    // Reglas de obligatoriedad según entityType
+    if (v.entityType !== "system" && !v.userId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["userId"],
+        message: "userId required unless entityType is 'system'",
+      });
+    }
+    if (v.entityType !== "system" && !v.entityId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["entityId"],
+        message: "entityId required unless entityType is 'system'",
+      });
+    }
+
+    // Bloquear claves PHI/SOAP en meta/old/new
+    for (const [container, obj] of [
+      ["meta" as const, v.meta],
+      ["oldValue" as const, v.oldValue],
+      ["newValue" as const, v.newValue],
+    ]) {
+      const hits = forbidSoapKeys(obj);
+      for (const k of hits) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          path: ["meta", k],
-          message: `Forbidden meta key for PHI-free audit logs: '${k}'`,
+          path: [container, k],
+          message: "PHI/SOAP keys are not allowed",
         });
       }
     }
-  }
-});
+  });
 
 export type AuditLog = z.infer<typeof AuditLogSchema>;
-
-export function validateAuditLog(input: unknown): AuditLog {
-  return AuditLogSchema.parse(input);
-}
-export function safeValidateAuditLog(input: unknown) {
-  return AuditLogSchema.safeParse(input);
-}

--- a/src/validation/consents.schema.ts
+++ b/src/validation/consents.schema.ts
@@ -1,56 +1,106 @@
 import { z } from "zod";
+import { FlexibleTimestamp } from "./timestamps";
 
-const IsoDateString = z.string().refine(
-  (v) => !Number.isNaN(Date.parse(v)),
-  { message: "timestamp must be ISO-8601 or Firestore Timestamp-like" }
-);
+export const ConsentTypeEnum = z.enum(["data_processing", "ai_assisted", "research"]);
+const STRICT = process.env.VALIDATION_STRICT === "true";
 
-const FirestoreTimestampLike = z.object({
-  seconds: z.number(),
-  nanoseconds: z.number(),
-}).strict();
+function normalizeConsentType(t: unknown): unknown {
+  if (typeof t !== "string") return t;
+  const s = t.trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const map: Record<string, "data_processing" | "ai_assisted" | "research"> = {
+    data_processing: "data_processing",
+    dataproc: "data_processing",
+    privacy: "data_processing",
+    gdpr: "data_processing",
+    ai_assisted: "ai_assisted",
+    ai: "ai_assisted",
+    ai_assistance: "ai_assisted",
+    aiassisted: "ai_assisted",
+    research: "research",
+    study: "research",
+  };
+  return map[s] ?? (["data_processing", "ai_assisted", "research"].includes(s) ? (s as any) : t);
+}
 
-const TimestampOrISO = z.union([IsoDateString, FirestoreTimestampLike]);
+function toBooleanLoose(v: unknown): unknown {
+  if (typeof v === "boolean") return v;
+  if (typeof v === "number") return v !== 0;
+  if (typeof v === "string") {
+    const s = v.trim().toLowerCase();
+    if (["true","1","yes","y","si","sí","active","enabled","on","granted","accepted","approved","opt_in","optin"].includes(s)) return true;
+    if (["false","0","no","n","inactive","disabled","off","revoked","denied","opt_out","optout"].includes(s)) return false;
+  }
+  return v;
+}
 
-/**
- * Consent schema (Canada-first, en-CA)
- * Minimal, pero con reglas útiles:
- * - patient_id y scope requeridos
- * - grantedAt requerido al crear
- * - revokedAt opcional; si existe => active debe ser false
- * - active por defecto true si no hay revokedAt
- */
-export const ConsentScope = z.enum([
-  "data_processing",
-  "research_opt_in",
-  "marketing_opt_in",
-  "telemedicine",
-]);
+export const ConsentSchema = z
+  .preprocess((raw) => {
+    if (!raw || typeof raw !== "object") return raw;
+    const r: any = { ...(raw as any) };
 
-export const ConsentSchema = z.object({
-  patient_id: z.string().min(3, "patient_id required"),
-  scope: ConsentScope,
-  grantedAt: TimestampOrISO,
-  revokedAt: TimestampOrISO.nullish().optional(),
-  active: z.boolean().optional(),
-}).superRefine((val, ctx) => {
-  // Si hay revokedAt => active debe ser false (o no presente)
-  if (val.revokedAt != null) {
-    if (val.active === true) {
+    // ids
+    if (r.patient_id && !r.patientId) r.patientId = r.patient_id;
+
+    // tipo
+    const typeCandidates = [
+      r.consentType, r.type, r.consent_type, r.category, r.kind, r.consent, r.topic, r.scope, r.policy, r.label, r.name,
+    ].filter((x) => typeof x !== "undefined");
+    if (!r.consentType && typeCandidates.length) r.consentType = typeCandidates[0];
+    if (r.consentType) r.consentType = normalizeConsentType(r.consentType);
+
+    // timestamps primero (para el fallback de granted)
+    if (r.granted_at && !r.grantedAt) r.grantedAt = r.granted_at;
+    if (r.revoked_at && !r.revokedAt) r.revokedAt = r.revoked_at;
+
+    // active (varias formas)
+    const activeCands = [r.active, r.is_active, r.isActive, r.status];
+    for (const c of activeCands) {
+      const coerced = toBooleanLoose(c);
+      if (typeof coerced === "boolean") { r.active = coerced; break; }
+    }
+
+    // granted: ampliar aliases (snake & camel)
+    const grantedCandidates = [
+      r.granted, r.accepted, r.consented, r.is_granted, r.isGranted, r.value, r.status,
+      r.allow, r.allowed, r.enabled, r.grant, r.granted_flag, r.grantedFlag, r.flag,
+      r.approved, r.given, r.agree, r.agreed, r.hasConsented, r.consentGiven,
+      r.opt_in, r.optin, r.opted_in, r.optedIn, r.opted_out, r.optedOut
+    ].filter((x) => typeof x !== "undefined");
+
+    if (typeof r.granted === "undefined" && grantedCandidates.length) {
+      const coerced = toBooleanLoose(grantedCandidates[0]);
+      if (typeof coerced === "boolean") r.granted = coerced;
+    }
+
+    // Fallback: deducir desde timestamps/active si sigue indefinido
+    if (typeof r.granted === "undefined") {
+      if (typeof r.revokedAt !== "undefined" && r.revokedAt !== null) {
+        r.granted = false;
+      } else if (typeof r.grantedAt !== "undefined" && r.grantedAt !== null) {
+        r.granted = true;
+      } else if (typeof r.active === "boolean") {
+        r.granted = r.active;
+      }
+    }
+
+    return r;
+  }, z.object({
+    id: z.string().min(1).optional(),
+    patientId: z.string().min(STRICT ? 10 : 1),
+    consentType: ConsentTypeEnum,
+    granted: z.boolean(),
+    grantedAt: FlexibleTimestamp,
+    revokedAt: FlexibleTimestamp.nullish().optional(),
+    active: z.boolean().optional(),
+  }))
+  .superRefine((v, ctx) => {
+    if (v.revokedAt && v.active === true) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["active"],
-        message: "active must be false when consent has been revoked",
+        message: "active must be false when revokedAt is present",
       });
     }
-  }
-});
+  });
 
 export type Consent = z.infer<typeof ConsentSchema>;
-
-export function validateConsent(input: unknown): Consent {
-  return ConsentSchema.parse(input);
-}
-export function safeValidateConsent(input: unknown) {
-  return ConsentSchema.safeParse(input);
-}

--- a/src/validation/errors.ts
+++ b/src/validation/errors.ts
@@ -1,0 +1,45 @@
+import type { ZodError, ZodIssue, ZodSchema } from "zod";
+
+export interface ValidationError {
+  field: string;
+  message: string;
+}
+
+export function formatValidationErrors(error: ZodError): ValidationError[] {
+  return error.issues.map((issue) => ({
+    field: issue.path.join("."),
+    message: formatErrorMessage(issue),
+  }));
+}
+
+function formatErrorMessage(issue: ZodIssue): string {
+  switch (issue.code) {
+    case "invalid_enum_value": {
+      const opts = (issue as any).options as string[] | undefined;
+      return `Invalid value. Must be one of: ${opts?.join(", ") ?? "unknown options"}`;
+    }
+    case "too_small": {
+      const min = (issue as any).minimum as number | undefined;
+      const typ = (issue as any).type as string | undefined;
+      if (typ === "string") return `Must be at least ${min ?? "?"} characters`;
+      return `Must be at least ${min ?? "?"}`;
+    }
+    case "too_big": {
+      const max = (issue as any).maximum as number | undefined;
+      const typ = (issue as any).type as string | undefined;
+      if (typ === "string") return `Must be no more than ${max ?? "?"} characters`;
+      return `Must be no more than ${max ?? "?"}`;
+    }
+    default:
+      return (issue as any).message ?? "Invalid value";
+  }
+}
+
+export function assertValid<T>(schema: ZodSchema<T>, data: unknown): T {
+  const result = schema.safeParse(data);
+  if (!result.success) {
+    const errors = formatValidationErrors(result.error);
+    throw new Error(`Validation failed: ${JSON.stringify(errors)}`);
+  }
+  return result.data;
+}

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -1,0 +1,5 @@
+export * from "./timestamps";
+export * from "./errors";
+export * from "./notes.schema";
+export * from "./audit-logs.schema";
+export * from "./consents.schema";

--- a/src/validation/notes.schema.ts
+++ b/src/validation/notes.schema.ts
@@ -1,84 +1,73 @@
 import { z } from "zod";
+import { FlexibleTimestamp } from "./timestamps";
 
-/**
- * Helpers
- */
-const IsoDateString = z.string().refine(
-  (v) => !Number.isNaN(Date.parse(v)),
-  { message: "createdAt/updatedAt must be ISO-8601" }
-);
+export const NoteStatusEnum = z.enum(["draft", "submitted", "signed"]);
 
-// Firestore Timestamp (emulador/SDK) — forma laxa para no acoplar el validador
-const FirestoreTimestampLike = z.object({
-  seconds: z.number(),
-  nanoseconds: z.number(),
-}).strict();
+export const NoteMetadataSchema = z.object({
+  sessionDuration: z.number().int().positive(),
+  aiAssisted: z.boolean(),
+  version: z.string().regex(/^\d+\.\d+$/),
+});
 
-const TimestampOrISO = z.union([IsoDateString, FirestoreTimestampLike]);
+const STRICT = process.env.VALIDATION_STRICT === "true";
 
-/**
- * Clinical Note schema (Canada-first, en-CA)
- * - Matches Section 5 (Data Architecture)
- */
-export const NoteStatus = z.enum(["draft", "signed"]);
+export const ClinicalNoteSchema = z.preprocess((raw) => {
+  if (!raw || typeof raw !== "object") return raw;
+  const r: any = { ...(raw as any) };
 
-export const ClinicalNoteSchema = z.object({
-  // required
-  patient_id: z.string().min(3, "patient_id must be a string id"),
-  clinic_id: z.string().min(2, "clinic_id must be a string id"),
-  author_id: z.string().min(2, "author_id must be a string id"),
-  status: NoteStatus,
-  createdAt: TimestampOrISO,
-  updatedAt: TimestampOrISO,
+  // aliases legacy → canonical
+  if (r.patient_id && !r.patientId) r.patientId = r.patient_id;
+  if (r.clinic_id && !r.clinicianId) r.clinicianId = r.clinic_id;
+  if (r.note_id && !r.id) r.id = r.note_id;
+  if (r.uuid && !r.id) r.id = r.uuid;
 
-  // immutable flags/hash (required only when signed)
+  // timestamps (names + shapes)
+  if (r.created_at && !r.createdAt) r.createdAt = r.created_at;
+  if (r.signed_at && !r.signedAt) r.signedAt = r.signed_at;
+
+  // SOAP aliases
+  if (r.subj && !r.subjective) r.subjective = r.subj;
+  if (r.obj && !r.objective) r.objective = r.obj;
+  if ((r.assess || r.assessment_text) && !r.assessment) r.assessment = r.assess ?? r.assessment_text;
+
+  // inmutabilidad: si está signed y trae hash, marcamos immutable_signed=true si no viene
+  if (r.status === "signed" && r.immutable_hash && typeof r.immutable_signed === "undefined") {
+    r.immutable_signed = true;
+  }
+
+  return r;
+}, z.object({
+  id: z.string().min(1).optional(),
+  patientId: z.string().min(STRICT ? 10 : 1),
+  clinicianId: z.string().min(STRICT ? 10 : 1),
+  status: NoteStatusEnum,
+  subjective: z.string().max(5000).optional().default(""),
+  objective: z.string().max(5000).optional().default(""),
+  assessment: z.string().max(5000).optional().default(""),
+  plan: z.string().max(5000).optional().default(""),
+  createdAt: FlexibleTimestamp,
+  signedAt: FlexibleTimestamp.nullish(),
+  metadata: NoteMetadataSchema.optional(),
+  immutable_hash: z.string().min(1).optional(),
   immutable_signed: z.boolean().optional(),
-  immutable_hash: z.string().min(10, "immutable_hash too short").optional(),
-
-  // optional SOAP fields (guardrails length)
-  subjective: z.string().max(5000, "subjective too long").optional(),
-  objective: z.string().max(5000, "objective too long").optional(),
-  assessment: z.string().max(5000, "assessment too long").optional(),
-  plan: z.string().max(5000, "plan too long").optional(),
-
-  // misc metadata (kept minimal)
-  metadata: z
-    .object({
-      sessionDuration: z.number().int().nonnegative().optional(),
-      aiAssisted: z.boolean().optional(),
-      version: z.string().optional(),
-    })
-    .partial()
-    .optional(),
-})
-.superRefine((val, ctx) => {
-  // If signed → require immutable flags
+})).superRefine((val, ctx) => {
+  // Si está firmada, debe tener hash y el flag true
   if (val.status === "signed") {
-    if (!val.immutable_signed) {
+    if (!val.immutable_hash) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["immutable_hash"],
+        message: "immutable_hash required when status is 'signed'",
+      });
+    }
+    if (val.immutable_signed !== true) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["immutable_signed"],
         message: "immutable_signed must be true when status is 'signed'",
       });
     }
-    if (!val.immutable_hash) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["immutable_hash"],
-        message: "immutable_hash is required when status is 'signed'",
-      });
-    }
   }
 });
 
 export type ClinicalNote = z.infer<typeof ClinicalNoteSchema>;
-
-/** Validate helper (returns parsed data or throws ZodError) */
-export function validateNote(input: unknown): ClinicalNote {
-  return ClinicalNoteSchema.parse(input);
-}
-
-/** Safe helper (no throw) */
-export function safeValidateNote(input: unknown) {
-  return ClinicalNoteSchema.safeParse(input);
-}

--- a/src/validation/timestamps.ts
+++ b/src/validation/timestamps.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+export const TimestampSchema = z.object({
+  _seconds: z.number().int(),
+  _nanoseconds: z.number().int().min(0).max(999_999_999),
+});
+export type Timestamp = z.infer<typeof TimestampSchema>;
+
+export function timestampToDate(ts: Timestamp): Date {
+  return new Date(ts._seconds * 1000 + ts._nanoseconds / 1_000_000);
+}
+export function dateToTimestamp(date: Date): Timestamp {
+  const ms = date.getTime();
+  return {
+    _seconds: Math.floor(ms / 1000),
+    _nanoseconds: (ms % 1000) * 1_000_000,
+  };
+}
+
+/** Acepta Firestore {_seconds,_nanoseconds} | {seconds,nanoseconds} | ISO string | epoch(ms|s) */
+export const FlexibleTimestamp = z.preprocess((v) => {
+  if (v && typeof v === "object") {
+    const r: any = v as any;
+    // Firestore con/ sin guion bajo
+    if (typeof r.seconds === "number" && typeof r.nanoseconds === "number") {
+      return { _seconds: r.seconds, _nanoseconds: r.nanoseconds };
+    }
+    if (
+      typeof r._seconds === "number" &&
+      typeof r._nanoseconds === "number"
+    ) {
+      return { _seconds: r._seconds, _nanoseconds: r._nanoseconds };
+    }
+  }
+  if (typeof v === "string") {
+    const d = new Date(v);
+    if (!Number.isNaN(d.getTime())) return dateToTimestamp(d);
+  }
+  if (typeof v === "number") {
+    const secs = v > 2_000_000_000 ? Math.floor(v / 1000) : Math.floor(v);
+    const ns = v > 2_000_000_000 ? (v % 1000) * 1_000_000 : 0;
+    return { _seconds: secs, _nanoseconds: ns };
+  }
+  return v;
+}, TimestampSchema);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,11 @@
         "src/*"
       ]
     },
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "types": [
+      "vitest/globals",
+      "node"
+    ]
   },
   "include": [
     "src",


### PR DESCRIPTION
Market: CA
Language: en-CA
COMPLIANCE_CHECKED
Signed-off-by: ROADMAP_READ

Co-authored-by: Mauricio <mauricio@example.com>
