### PR TITLE
fix(sign-note): reapply integration removed by history rewrite

### DIFF
--- a/src/api/notes.ts
+++ b/src/api/notes.ts
@@ -1,0 +1,20 @@
+export interface SignResponse { ok: boolean; message?: string }
+
+export async function signNote(noteId: string): Promise<SignResponse> {
+  if (!noteId) return { ok: false, message: 'Missing noteId' };
+  const res = await fetch(`/notes/${encodeURIComponent(noteId)}/sign`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+  });
+  if (!res.ok) {
+    let msg = 'Failed to sign note';
+    try {
+      const data = await res.json();
+      if (data?.error) msg = String(data.error);
+      if (data?.message) msg = String(data.message);
+    } catch {}
+    return { ok: false, message: msg };
+  }
+  return { ok: true };
+}

--- a/src/components/AppToastProvider.tsx
+++ b/src/components/AppToastProvider.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+import { ToastProvider } from '../hooks/useToast';
+export default function AppToastProvider({ children }: { children: React.ReactNode }) {
+  return <ToastProvider>{children}</ToastProvider>;
+}

--- a/src/components/NoteActions.tsx
+++ b/src/components/NoteActions.tsx
@@ -1,0 +1,68 @@
+import React, { useMemo, useState } from 'react';
+import SignNoteModal from './SignNoteModal';
+import { signNote } from '../api/notes';
+import { useToast } from '../hooks/useToast';
+
+type SOAP = { subjective?: string; objective?: string; assessment?: string; plan?: string };
+type Props = {
+  noteId: string;
+  status: 'draft' | 'submitted' | 'signed';
+  soap: SOAP;
+  onSigned?: () => void; // notify parent to refresh
+};
+
+function isSoapComplete(soap: SOAP) {
+  return Boolean(soap?.subjective && soap?.objective && soap?.assessment && soap?.plan);
+}
+
+export default function NoteActions({ noteId, status, soap, onSigned }: Props) {
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const { notify } = useToast();
+
+  const canSign = useMemo(() => isSoapComplete(soap), [soap]);
+
+  const handleConfirm = async () => {
+    setBusy(true);
+    const res = await signNote(noteId);
+    setBusy(false);
+    setOpen(false);
+    if (res.ok) {
+      notify('Note signed successfully.');
+      onSigned?.();
+    } else {
+      notify(res.message || 'Failed to sign note.');
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      {status === 'submitted' && (
+        <button
+          onClick={() => setOpen(true)}
+          className="px-3 py-2 rounded-lg bg-black text-white disabled:opacity-40"
+          disabled={!canSign || busy}
+          aria-disabled={!canSign || busy}
+          aria-label="Sign Note"
+        >
+          {busy ? 'Signing…' : 'Sign Note'}
+        </button>
+      )}
+
+      <SignNoteModal
+        open={open}
+        onClose={() => setOpen(false)}
+        onConfirm={handleConfirm}
+        soapPreview={
+          <div className="text-sm space-y-2">
+            <p><strong>Subjective:</strong> {soap?.subjective ?? '—'}</p>
+            <p><strong>Objective:</strong> {soap?.objective ?? '—'}</p>
+            <p><strong>Assessment:</strong> {soap?.assessment ?? '—'}</p>
+            <p><strong>Plan:</strong> {soap?.plan ?? '—'}</p>
+          </div>
+        }
+        canSign={canSign}
+      />
+    </div>
+  );
+}

--- a/src/hooks/useToast.tsx
+++ b/src/hooks/useToast.tsx
@@ -1,0 +1,27 @@
+import React, { createContext, useCallback, useContext, useState } from 'react';
+
+type Toast = { id: number; text: string };
+type Ctx = { notify: (text: string) => void };
+
+const ToastCtx = createContext<Ctx>({ notify: () => {} });
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const notify = useCallback((text: string) => {
+    const id = Date.now();
+    setToasts((t) => [...t, { id, text }]);
+    setTimeout(() => setToasts((t) => t.filter(x => x.id !== id)), 5000);
+  }, []);
+  return (
+    <ToastCtx.Provider value={{ notify }}>
+      {children}
+      <div aria-live="assertive" role="status" className="fixed bottom-4 right-4 space-y-2 z-50">
+        {toasts.map(t => (
+          <div key={t.id} className="rounded-xl shadow px-3 py-2 border bg-white">{t.text}</div>
+        ))}
+      </div>
+    </ToastCtx.Provider>
+  );
+}
+
+export const useToast = () => useContext(ToastCtx);


### PR DESCRIPTION
Reapplies the Sign Note integration that was dropped after a forced update on release/beta-w43.

Includes:
- NoteActions.tsx (button → modal → PUT /notes/:id/sign)
- api/notes.ts
- useToast + AppToastProvider
- A11y: dialog role + aria-labelledby, aria-live=assertive

Closes #233
