### PR TITLE
ci: write-facade guardrails for main (workflow + ADR + gate)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,6 @@
+# Write-facade governance (explicit review path; same owners as default)
+.github/direct-write-facade-allowlist.json @Maurosg78 @AIDUXCARE
+.github/workflows/write-facade-enforcement.yml @Maurosg78 @AIDUXCARE
+docs/adr/0002-enforce-direct-writes-through-persistence-facade.md @Maurosg78 @AIDUXCARE
+
 * @Maurosg78 @AIDUXCARE

--- a/.github/direct-write-facade-allowlist.json
+++ b/.github/direct-write-facade-allowlist.json
@@ -1,0 +1,10 @@
+{
+  "allowedWriterFiles": [
+    "src/services/PersistenceService.ts",
+    "src/services/PersistenceService.js",
+    "src/services/PersistenceServiceEnhanced.ts",
+    "src/services/PersistenceServiceEnhanced.js",
+    "src/services/notePersistence.ts",
+    "src/services/notePersistence.js"
+  ]
+}

--- a/.github/workflows/write-facade-enforcement.yml
+++ b/.github/workflows/write-facade-enforcement.yml
@@ -1,0 +1,23 @@
+name: Enforce Write Facade
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  enforce-write-facade:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Block direct datastore writers outside facade
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/check-direct-writes-outside-facade.mjs

--- a/docs/adr/0002-enforce-direct-writes-through-persistence-facade.md
+++ b/docs/adr/0002-enforce-direct-writes-through-persistence-facade.md
@@ -1,0 +1,38 @@
+# ADR-0002: Enforce direct writes through the persistence facade
+
+- **Date:** 2026-03-27
+- **Status:** Accepted
+- **Context**
+  The codebase has accumulated direct Firestore and Supabase write calls across multiple UI and service files. That makes auditability, invariants, retries, encryption, and future storage migrations harder to control. The immediate need is not to refactor all legacy writers at once, but to stop the problem from growing.
+
+- **Decision**
+  New direct datastore write calls in application runtime code must go through an approved persistence facade. CI will fail pull requests that add direct write primitives outside the allowlisted facade files.
+
+  Initial enforcement scope:
+  - Runtime app code under `src/**/*.{js,jsx,ts,tsx}`
+  - Excludes tests (`__tests__`, `*.test.*`, `*.spec.*`)
+  - Detects newly added direct write calls in PR diff only
+  - Blocks direct Firestore writes such as `setDoc`, `addDoc`, `updateDoc`, `deleteDoc`, `writeBatch`, `runTransaction`
+  - Blocks direct Supabase writes such as `.insert()`, `.update()`, `.upsert()`, `.delete()`
+  - Allows writes only in the facade files declared in `.github/direct-write-facade-allowlist.json`
+  - Changes to `.github/direct-write-facade-allowlist.json` require an ADR update in the same PR and architecture owner review
+
+- **Consequences**
+  - (+) Prevents further architectural drift without forcing a big-bang migration.
+  - (+) Makes write-path review explicit and enforceable in PRs.
+  - (+) Centralizes retries, encryption, validation, and audit hooks behind a smaller surface.
+  - (-) Legacy direct writers remain until migrated; this ADR only freezes net-new spread.
+  - (-) The allowlist becomes a governance artifact and must be updated deliberately when the facade evolves.
+  - Follow-up: migrate existing direct writers into the facade in bounded batches, then tighten CI from diff-based enforcement to full-tree enforcement.
+  - Phase 2 target: 2026-06-30, with domain-by-domain full-tree enforcement once high-volume legacy writers have been migrated.
+
+- **Alternatives Considered**
+  Full-repo blocking now: strongest purity, but unrealistic given current legacy footprint.
+  Review guideline only: low effort, but non-enforceable and easy to bypass under delivery pressure.
+  ESLint custom rule first: viable later, but a diff-based CI script is faster to land and easier to tune against current debt.
+
+- **Links**
+  - Docs: `/.github/direct-write-facade-allowlist.json`
+  - Docs: `/docs/adr/README.md`
+  - Runbook: `/docs/operations/BRANCH_PROTECTION_WRITE_FACADE_RUNBOOK.md`
+  - Owner: `@Maurosg78`, `@AIDUXCARE`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,6 +12,7 @@ Lightweight records of consequential decisions. One file per decision.
 <!-- Example:
 - ADR-0001: Enable TypeScript strict mode — 2025-09-25 (status: Accepted)
 -->
+- ADR-0002: Enforce direct writes through the persistence facade — 2026-03-27 (status: Accepted)
 
 ## Pre-push (bypass para cambios meta)
 - Si el cambio incluye **solo** archivos dentro de `docs/adr/**` o el `.gitignore`,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint:prod": "eslint \"src/**/*.{ts,tsx}\" --report-unused-disable-directives --max-warnings 0",
     "lint": "eslint .",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix --fix-type layout,suggestion",
+    "check:write-facade": "node scripts/check-direct-writes-outside-facade.mjs",
     "validate:canonical": "bash scripts/validate-canonical-imports.sh",
     "typecheck": "echo '⏭️ typecheck saltado temporalmente'",
     "preview": "vite preview",
@@ -139,5 +140,6 @@
   "volta": {
     "node": "20.19.0",
     "npm": "10.8.2"
-  }
+  },
+  "packageManager": "pnpm@10.29.2+sha512.bef43fa759d91fd2da4b319a5a0d13ef7a45bb985a3d7342058470f9d2051a3ba8674e629672654686ef9443ad13a82da2beb9eeb3e0221c87b8154fff9d74b8"
 }

--- a/scripts/check-direct-writes-outside-facade.mjs
+++ b/scripts/check-direct-writes-outside-facade.mjs
@@ -1,0 +1,154 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const repoRoot = process.cwd();
+const allowlistPath = path.join(repoRoot, '.github', 'direct-write-facade-allowlist.json');
+const { allowedWriterFiles } = JSON.parse(readFileSync(allowlistPath, 'utf8'));
+const allowedFiles = new Set(allowedWriterFiles);
+
+const TARGET_FILE_RE = /^src\/.*\.(js|jsx|ts|tsx)$/;
+const TEST_FILE_RE = /(^|\/)__tests__\/|\.test\.(js|jsx|ts|tsx)$|\.spec\.(js|jsx|ts|tsx)$/;
+export const FORBIDDEN_WRITE_RE = /\b(setDoc|addDoc|updateDoc|deleteDoc|writeBatch|runTransaction)\s*\(|\.(insert|update|upsert|delete)\s*\(/;
+
+function git(args) {
+  return execFileSync('git', args, { cwd: repoRoot, encoding: 'utf8' }).trim();
+}
+
+function resolveBaseHead() {
+  const envBase = process.env.BASE_SHA;
+  const envHead = process.env.HEAD_SHA;
+  if (envBase && envHead) {
+    return { base: envBase, head: envHead };
+  }
+
+  const candidates = [
+    ['merge-base', 'HEAD', 'origin/main'],
+    ['merge-base', 'HEAD', 'main'],
+  ];
+
+  for (const args of candidates) {
+    try {
+      const base = git(args);
+      if (base) {
+        return { base, head: 'HEAD' };
+      }
+    } catch {
+      // Try next candidate.
+    }
+  }
+
+  try {
+    const base = git(['rev-parse', 'HEAD^']);
+    if (base) {
+      console.warn('WARN: origin/main not available; falling back to HEAD^..HEAD for local smoke check.');
+      return { base, head: 'HEAD' };
+    }
+  } catch {
+    // Fall through to hard failure.
+  }
+
+  throw new Error(
+    'Unable to resolve BASE_SHA/HEAD_SHA. Set BASE_SHA and HEAD_SHA, fetch origin/main, or run from a branch with at least one local commit.'
+  );
+}
+
+function listChangedFiles(base, head) {
+  const output = git(['diff', '--name-only', `${base}..${head}`]);
+  if (!output) {
+    return [];
+  }
+
+  return output
+    .split('\n')
+    .map((file) => file.trim())
+    .filter(Boolean)
+    .filter((file) => TARGET_FILE_RE.test(file))
+    .filter((file) => !TEST_FILE_RE.test(file));
+}
+
+export function scanPatchForViolations(diff, file) {
+  if (!diff) {
+    return [];
+  }
+
+  const violations = [];
+  let currentLine = 0;
+
+  for (const line of diff.split('\n')) {
+    const hunkMatch = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+    if (hunkMatch) {
+      currentLine = Number.parseInt(hunkMatch[1], 10);
+      continue;
+    }
+
+    if (line.startsWith('+++') || line.startsWith('---') || line.startsWith('diff --git') || line.startsWith('index ')) {
+      continue;
+    }
+
+    if (line.startsWith('+')) {
+      const content = line.slice(1);
+      if (FORBIDDEN_WRITE_RE.test(content)) {
+        violations.push({ file, line: currentLine, content: content.trim() });
+      }
+      currentLine += 1;
+      continue;
+    }
+
+    if (line.startsWith(' ')) {
+      currentLine += 1;
+    }
+  }
+
+  return violations;
+}
+
+export function findViolationsForFile(file, diff, allowedFileSet = allowedFiles) {
+  if (allowedFileSet.has(file)) {
+    return [];
+  }
+
+  return scanPatchForViolations(diff, file);
+}
+
+function scanDiffForViolations(base, head, file) {
+  const diff = git(['diff', '--unified=0', '--no-color', `${base}..${head}`, '--', file]);
+  return findViolationsForFile(file, diff);
+}
+
+function main() {
+  const { base, head } = resolveBaseHead();
+  const changedFiles = listChangedFiles(base, head);
+  const violations = [];
+
+  for (const file of changedFiles) {
+    if (allowedFiles.has(file)) {
+      continue;
+    }
+
+    violations.push(...scanDiffForViolations(base, head, file));
+  }
+
+  if (violations.length === 0) {
+    console.log(`OK: no new direct datastore writers outside the facade between ${base} and ${head}.`);
+    return;
+  }
+
+  console.error('Direct datastore writers were added outside the approved facade:');
+  for (const violation of violations) {
+    console.error(`- ${violation.file}:${violation.line} -> ${violation.content}`);
+  }
+  console.error('');
+  console.error('Allowed facade files:');
+  for (const file of allowedFiles) {
+    console.error(`- ${file}`);
+  }
+  console.error('');
+  console.error('Move the write behind the facade or update the allowlist intentionally with ADR coverage.');
+  process.exit(1);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/test/architecture/writeFacadeGate.spec.ts
+++ b/test/architecture/writeFacadeGate.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { findViolationsForFile } from '../../scripts/check-direct-writes-outside-facade.mjs';
+
+describe('write facade gate', () => {
+  it('accepts writes inside an allowlisted facade file', () => {
+    const diff = [
+      'diff --git a/src/services/PersistenceService.ts b/src/services/PersistenceService.ts',
+      '@@ -10,0 +11,1 @@',
+      '+await setDoc(docRef, payload);',
+    ].join('\n');
+
+    const violations = findViolationsForFile(
+      'src/services/PersistenceService.ts',
+      diff,
+      new Set(['src/services/PersistenceService.ts'])
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  it('blocks direct writes added outside the facade', () => {
+    const diff = [
+      'diff --git a/src/pages/NotesPage.tsx b/src/pages/NotesPage.tsx',
+      '@@ -44,0 +45,2 @@',
+      '+const result = await supabase.from(\'notes\')',
+      '+  .insert(payload);',
+    ].join('\n');
+
+    const violations = findViolationsForFile(
+      'src/pages/NotesPage.tsx',
+      diff,
+      new Set(['src/services/PersistenceService.ts'])
+    );
+
+    expect(violations).toEqual([
+      {
+        file: 'src/pages/NotesPage.tsx',
+        line: 46,
+        content: '.insert(payload);',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
Cierra la brecha entre branch protection y el código en `main`: añade el workflow **Enforce Write Facade**, el script de comprobación, allowlist, ADR-0002, test de arquitectura y entradas CODEOWNERS.

## Why
La rama `main` ya exige el check `Enforce Write Facade / enforce-write-facade` en protección de ramas; este PR aporta el workflow para que el check pueda ejecutarse y completarse.

## Includes
- `.github/workflows/write-facade-enforcement.yml`
- `scripts/check-direct-writes-outside-facade.mjs`
- `.github/direct-write-facade-allowlist.json`
- `docs/adr/0002-enforce-direct-writes-through-persistence-facade.md` + índice en `docs/adr/README.md`
- `test/architecture/writeFacadeGate.spec.ts`
- `package.json`: `check:write-facade`
- `.github/CODEOWNERS`: rutas de gobernanza explícitas

## Verify
- En la pestaña Checks del PR debe aparecer **Enforce Write Facade** en verde.
- Tras merge, actualizar evidencia en `docs/audit-trail/2026-03-27-branch-protection/`.

Made with [Cursor](https://cursor.com)